### PR TITLE
add TEEP extension, media types and registrations

### DIFF
--- a/cddl/examples/ext-teep-json-1.diag
+++ b/cddl/examples/ext-teep-json-1.diag
@@ -9,7 +9,7 @@
   },
   "iat": 1666529284,
   "ear.appraisal-policy-id": "https://veraison.example/policy/1/60a0068d",
-  "ear.teep.claims": {
+  "ear.teep-claims": {
     "nonce": "80FH7byS7VjfARIq0_KLqu6B9j-F79QtV6p",
     "ueid": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAh",
     "oemid": "Av8B",

--- a/cddl/examples/ext-veraison-cbor-1.diag
+++ b/cddl/examples/ext-veraison-cbor-1.diag
@@ -10,7 +10,7 @@
   1002: h'6C696665626F61746D616E',
   1003: "https://veraison.example/policy/1/60a0068d",
   6: 1666529184,
-  64000: {
+  -70000: {
     "eat-profile": "http://arm.com/psa/2.0.0",
     "psa-client-id": 1,
     "psa-security-lifecycle": 12288,
@@ -29,7 +29,7 @@
     "psa-instance-id": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAh",
     "psa-certification-reference": "1234567890123-12345"
   },
-  64001: {
+  -70001: {
     "psa-certified": {
       "certificate-number": "1234567890123-12345",
       "date-of-issue": "23/06/2022",

--- a/cddl/teep-cbor-labels.cddl
+++ b/cddl/teep-cbor-labels.cddl
@@ -1,5 +1,3 @@
 ear.teep.claims = 65000
 
 ; TODO
-
-; vim: set tw=70 ts=2 et:

--- a/cddl/teep-json-labels.cddl
+++ b/cddl/teep-json-labels.cddl
@@ -34,5 +34,3 @@ oemid-ieee = base64-url-text ; cddl(1)-unsupported: .size 4
 oemid-random = base64-url-text ; cddl(1)-unsupported: .size 24
 
 base64-url-text = tstr .regexp "[A-Za-z0-9_=-]+"
-
-; vim: set tw=70 ts=2 et:

--- a/cddl/teep.cddl
+++ b/cddl/teep.cddl
@@ -1,5 +1,5 @@
 $$ear-extension //= (
-  ear.teep.claims => ear-teep-claims
+  ear.teep-claims => ear-teep-claims
 )
 
 ear-teep-claims = non-empty<{
@@ -10,5 +10,3 @@ ear-teep-claims = non-empty<{
   ? eat.hardware-version => eat.hardware-version-type
   ? eat.manifests => eat.manifests-type
 }>
-
-; vim: set tw=70 ts=2 et:

--- a/cddl/veraison-cbor-labels.cddl
+++ b/cddl/veraison-cbor-labels.cddl
@@ -1,4 +1,2 @@
-ear.veraison.processed-evidence = 64000
-ear.veraison.verifier-added-claims = 64001
-
-; vim: set tw=70 ts=2 et:
+ear.veraison.processed-evidence = -70000
+ear.veraison.verifier-added-claims = -70001

--- a/cddl/veraison-json-labels.cddl
+++ b/cddl/veraison-json-labels.cddl
@@ -1,4 +1,5 @@
-ear.veraison.processed-evidence = "ear.veraison.processed-evidence"
-ear.veraison.verifier-added-claims = "ear.veraison.verifier-added-claims"
+ear.veraison.processed-evidence =
+  "ear.veraison.processed-evidence"
 
-; vim: set tw=70 ts=2 et:
+ear.veraison.verifier-added-claims =
+  "ear.veraison.verifier-added-claims"

--- a/cddl/veraison.cddl
+++ b/cddl/veraison.cddl
@@ -1,5 +1,6 @@
 $$ear-extension //= (
-  ear.veraison.processed-evidence => ear-veraison-processed-evidence
+  ear.veraison.processed-evidence =>
+    ear-veraison-processed-evidence
 )
 
 ear-veraison-processed-evidence = {
@@ -7,11 +8,10 @@ ear-veraison-processed-evidence = {
 }
 
 $$ear-extension //= (
-  ear.veraison.verifier-added-claims => ear-veraison-verifier-added-claims
+  ear.veraison.verifier-added-claims =>
+    ear-veraison-verifier-added-claims
 )
 
 ear-veraison-verifier-added-claims = {
   + ear-label => any
 }
-
-; vim: set tw=70 ts=2 et:

--- a/draft-fv-rats-ear.md
+++ b/draft-fv-rats-ear.md
@@ -49,6 +49,7 @@ normative:
   I-D.ietf-rats-ar4si: ar4si
   I-D.ietf-rats-architecture: rats-arch
   I-D.ietf-rats-eat: eat
+  I-D.ietf-teep-protocol: teep
 
 informative:
   RFC7942: impl-status
@@ -117,26 +118,35 @@ Where:
 
 {:vspace}
 `ear.status` (mandatory)
-: The overall appraisal status represented as one of the four trustworthiness tiers ({{sec-trusttiers}}).
-If the `ear.trustworthiness-vector` claim is also present, the value of this claim MUST be set to a tier of no higher trust than the tier corresponding to the worst trustworthiness claim across the entire trustworthiness vector.
+: The overall appraisal status represented as one of the four trustworthiness
+tiers ({{sec-trusttiers}}).
+If the `ear.trustworthiness-vector` claim is also present, the value of this
+claim MUST be set to a tier of no higher trust than the tier corresponding to
+the worst trustworthiness claim across the entire trustworthiness vector.
 
 `eat_profile` (mandatory)
-: The EAT profile ({{Section 6 of -eat}}) associated with the EAR claims-set and encodings defined by this document.
-It MUST be the following tag URI ({{-tag-uri}}) `tag:github.com,2022:veraison/ear`.
+: The EAT profile ({{Section 6 of -eat}}) associated with the EAR claims-set
+and encodings defined by this document.
+It MUST be the following tag URI ({{-tag-uri}})
+`tag:github.com,2022:veraison/ear`.
 
 `ear.trustworthiness-vector` (optional)
 : The AR4SI trustworthiness vector providing the breakdown of the appraisal.
 See {{sec-tvector}} for the details.
 
 `ear.raw-evidence` (optional)
-: The unabridged evidence submitted for appraisal, including any signed container/envelope.
+: The unabridged evidence submitted for appraisal, including any signed
+container/envelope.
 
 `iat` (mandatory)
 : "Issued At" claim -- the time at which the EAR is issued.
-See {{Section 4.1.6 of -jwt}} and {{Section 4.3.1 of -eat}} for the EAT-specific encoding restrictions (i.e., disallowing the floating point representation).
+See {{Section 4.1.6 of -jwt}} and {{Section 4.3.1 of -eat}} for the
+EAT-specific encoding restrictions (i.e., disallowing the floating point
+representation).
 
 `ear.appraisal-policy-id` (optional)
-: An unique identifier of the appraisal policy used to evaluate the attestation result.
+: An unique identifier of the appraisal policy used to evaluate the attestation
+result.
 
 `$$ear-extension` (optional)
 : Any application- or deployment-specific extension.
@@ -145,22 +155,30 @@ See {{sec-extensions}} for further details.
 
 ## Trustworthiness Vector {#sec-tvector}
 
-The `ar4si-trustworthiness-vector` claim is an embodiment of the AR4SI trustworthiness vector ({{Section 2.3.5 of -ar4si}}) and it is defined as follows:
+The `ar4si-trustworthiness-vector` claim is an embodiment of the AR4SI
+trustworthiness vector ({{Section 2.3.5 of -ar4si}}) and it is defined as
+follows:
 
 ~~~cddl
 {::include cddl/trustworthiness-vector.cddl}
 ~~~
 {: #fig-cddl-tvec title="Trustworthiness Vector (CDDL Definition)" }
 
-It contains an entry for each one of the eight AR4SI appraisals that have been conducted on the submitted evidence ({{Section 2.3.4 of -ar4si}}).
-The value of each entry is chosen in the -128..127 range according to the rules described in {{Sections 2.3.3 and 2.3.4 of -ar4si}}.
+It contains an entry for each one of the eight AR4SI appraisals that have been
+conducted on the submitted evidence ({{Section 2.3.4 of -ar4si}}).
+The value of each entry is chosen in the -128..127 range according to the rules
+described in {{Sections 2.3.3 and 2.3.4 of -ar4si}}.
 All categories are optional.
-A missing entry means that the verifier makes no claim about this specific appraisal facet because the category is not applicable to the submitted evidence.
-As required by the `non-empty` macro, at least one entry MUST be present in the vector.
+A missing entry means that the verifier makes no claim about this specific
+appraisal facet because the category is not applicable to the submitted
+evidence.
+As required by the `non-empty` macro, at least one entry MUST be present in the
+vector.
 
 ## Trust Tiers {#sec-trusttiers}
 
-The trust tier type represents one of the equivalency classes in which the `$ar4si-trustworthiness-claim` space is partitioned.
+The trust tier type represents one of the equivalency classes in which the
+`$ar4si-trustworthiness-claim` space is partitioned.
 See {{Section 2.3.2 of -ar4si}} for the details.
 The allowed values for the type are as follows:
 
@@ -171,7 +189,9 @@ The allowed values for the type are as follows:
 
 ## JSON Serialisation
 
-To serialize the EAR claims-set in JSON format, the following substitutions are applied to the encoding-agnostic CDDL definitions in {{sec-ear}}, {{sec-tvector}} and {{sec-trusttiers}}:
+To serialize the EAR claims-set in JSON format, the following substitutions are
+applied to the encoding-agnostic CDDL definitions in {{sec-ear}},
+{{sec-tvector}} and {{sec-trusttiers}}:
 
 ~~~cddl
 {::include cddl/json-labels.cddl}
@@ -179,8 +199,12 @@ To serialize the EAR claims-set in JSON format, the following substitutions are 
 
 ### Examples
 
-The example in {{fig-ex-json-1}} shows an EAR claims-set corresponding to a "contraindicated" appraisal, meaning the verifier has found some problems with the attester's state reported in the submitted evidence.
-Specifically, the identified issue is related to unauthorized code or configuration loaded in runtime memory (i.e., value 96 in the executables category).
+The example in {{fig-ex-json-1}} shows an EAR claims-set corresponding to a
+"contraindicated" appraisal, meaning the verifier has found some problems with
+the attester's state reported in the submitted evidence.
+Specifically, the identified issue is related to unauthorized code or
+configuration loaded in runtime memory (i.e., value 96 in the executables
+category).
 
 ~~~cbor-diag
 {::include cddl/examples/ear-json-1.diag}
@@ -198,7 +222,8 @@ The breakdown of the trustworthiness vector is as follows:
 * Storage Opaque (none): no claim being made
 * Sourced Data (none): no claim being made
 
-The example in {{fig-ex-json-2}} is a minimalist (successful) attestation result that doesn't carry a trustworthiness vector.
+The example in {{fig-ex-json-2}} is a minimalist (successful) attestation
+result that doesn't carry a trustworthiness vector.
 
 ~~~cbor-diag
 {::include cddl/examples/ear-json-2.diag}
@@ -219,20 +244,41 @@ The example in {{fig-ex-json-2}} is a minimalist (successful) attestation result
 
 ## Extensions {#sec-extensions}
 
-The EAR claims-set can be extended by plugging new claims into the `$$ear-extension` CDDL socket.
-This specification anticipates two kinds of extensions: standard and custom.
-Standard extensions broaden
-EAR can also accommodate per-application and per-deployment extensions.
+EAR provides core semantics for describing the result of appraising attestation
+evidence.
+However, a given deployment may offer extra functionality to its relying
+parties, or tailor the attestation result to the needs of an application (e.g.,
+TEEP {{-teep}}).
+To accommodate such cases, the EAR claims-set can be extended by plugging new
+claims into the `$$ear-extension` CDDL socket.
 
-Standard extensions can be simple or complex (e.g., sub-maps) claims.
-Standard extensions are registered using the procedure defined in {{sec-iana-ear-ext}}.
+The rules that govern extensibility of EAR are those defined in {{-cwt}} and
+{{-jwt}} for CWTs and JWTs respectively.
+An up-to-date view of the registered claims can be obtained via the
+{{?IANA.cwt}} and {{?IANA.jwt}} registries.
 
-Keys for private extensions MUST be chosen as follows:
+A deployment-specific extension will normally mint its claim from the "private
+space" - using integer values less than -65536 for CWT, and Public or
+Private Claim Names as defined in {{Sections 4.2 and 4.3 of -jwt}} when
+serializing to JWT.
+It is RECOMMENDED that JWT EARs use Collision-Resistant Public Claim Names
+({{Section 2 of -jwt}}) rather than Private Claim Names.
 
-* negative integers for CBOR serialization
+If there is even the slightest chance that an application-specific extension
+will be used across multiple environments, the associated extension claim
+SHOULD be registered in one, or both, the CWT and JWT claim registries.
+Since there is in general no guarantee that an application will be confined
+within an environment, it is RECOMMENDED that application-specific extension
+claims are always registered.
 
+In general, if the registration policy requires an accompanying specification
+document (as it is the case for "specification required" and "standards
+action"), such document SHOULD explicitly say that the extension is expected to
+be used in EAR claims-sets identified by this profile.
 
-In general, a receiver MUST ignore any unknown claim, standard or private.
+An extension MUST NOT change the semantics of the base EAR claims-set.
+
+A receiver MUST ignore any unknown claim.
 
 # Implementation Status
 
@@ -277,7 +323,7 @@ TODO Security
 
 # IANA Considerations
 
-## Standard EAR Key Registry {#sec-iana-ear-ext}
+## New EAT Claims {#sec-iana-ear-claims}
 
 TODO
 

--- a/draft-fv-rats-ear.md
+++ b/draft-fv-rats-ear.md
@@ -242,7 +242,7 @@ result that doesn't carry a trustworthiness vector.
 {::include cddl/examples/ear-cbor-1.diag}
 ~~~
 
-## Extensions {#sec-extensions}
+# EAR Extensions {#sec-extensions}
 
 EAR provides core semantics for describing the result of appraising attestation
 evidence.
@@ -279,6 +279,47 @@ be used in EAR claims-sets identified by this profile.
 An extension MUST NOT change the semantics of the base EAR claims-set.
 
 A receiver MUST ignore any unknown claim.
+
+## Veraison Deployment Extensions
+
+The Veraison verifier defines two private, deployment-specific extensions:
+
+* Processed Evidence:
+: The appraised evidence claims-set converted into a JSON object.
+
+* Verifier Added Claims:
+: A JSON map containing any claims about the attester that are inferred by the
+verifier during the appraisal process.  For example: the certification status
+associated with the device, or any other endorsed attribute.
+
+~~~cddl
+{::include cddl/veraison.cddl}
+~~~
+{: #fig-cddl-veraison title="Veraison Deployment Extensions (CDDL Definition)" }
+
+### JSON Serialization
+
+~~~cddl
+{::include cddl/veraison-json-labels.cddl}
+~~~
+
+Example:
+
+~~~cbor-diag
+{::include cddl/examples/ext-veraison-json-1.diag}
+~~~
+
+### CBOR Serialization
+
+~~~cddl
+{::include cddl/veraison-cbor-labels.cddl}
+~~~
+
+Example:
+
+~~~cbor-diag
+{::include cddl/examples/ext-veraison-cbor-1.diag}
+~~~
 
 # Implementation Status
 

--- a/draft-fv-rats-ear.md
+++ b/draft-fv-rats-ear.md
@@ -50,10 +50,13 @@ normative:
   I-D.ietf-rats-architecture: rats-arch
   I-D.ietf-rats-eat: eat
   I-D.ietf-teep-protocol: teep
+  I-D.ietf-rats-eat-media-type: eat-media-type
 
 informative:
   RFC7942: impl-status
   RFC4151: tag-uri
+  IANA.cwt:
+  IANA.jwt:
 
 entity:
   SELF: "RFCthis"
@@ -255,7 +258,7 @@ claims into the `$$ear-extension` CDDL socket.
 The rules that govern extensibility of EAR are those defined in {{-cwt}} and
 {{-jwt}} for CWTs and JWTs respectively.
 An up-to-date view of the registered claims can be obtained via the
-{{?IANA.cwt}} and {{?IANA.jwt}} registries.
+{{IANA.cwt}} and {{IANA.jwt}} registries.
 
 A deployment-specific extension will normally mint its claim from the "private
 space" - using integer values less than -65536 for CWT, and Public or
@@ -279,6 +282,40 @@ be used in EAR claims-sets identified by this profile.
 An extension MUST NOT change the semantics of the base EAR claims-set.
 
 A receiver MUST ignore any unknown claim.
+
+## TEEP Application Extensions {#sec-extensions-teep}
+
+The TEEP protocol {{-teep}} specifies the required claims that an attestation
+result must carry for a TAM (Trusted Application Manager) to make decisions on
+how to remediate a TEE (Trusted Execution Environment) that is out of
+compliance, or update a TEE that is requesting an authorized change.
+
+The list is provided in {{Section 4.3.1 of -teep}}.
+
+EAR defines a TEEP application extension for the purpose of conveying such claims.
+
+~~~cddl
+{::include cddl/teep.cddl}
+~~~
+{: #fig-cddl-teep title="TEEP Application Extension (CDDL Definition)" }
+
+### JSON Serialization
+
+~~~cddl
+{::include cddl/teep-json-labels.cddl}
+~~~
+
+Example:
+
+~~~cddl
+{::include cddl/examples/ext-teep-json-1.diag}
+~~~
+
+### CBOR Serialization
+
+~~~cddl
+{::include cddl/teep-cbor-labels.cddl}
+~~~
 
 ## Veraison Deployment Extensions
 
@@ -319,6 +356,23 @@ Example:
 
 ~~~cbor-diag
 {::include cddl/examples/ext-veraison-cbor-1.diag}
+~~~
+
+# Media Types
+
+Media types for EAR are automatically derived from the base EAT media type
+{{-eat-media-type}} using the profile string defined in {{sec-ear}}.
+
+For example, a JWT serialization would use:
+
+~~~
+application/eat-jwt; eat_profile="tag:github.com,2022:veraison/ear"
+~~~
+
+A CWT serialization would instead use:
+
+~~~
+application/eat-cwt; eat_profile="tag:github.com,2022:veraison/ear"
 ~~~
 
 # Implementation Status
@@ -366,7 +420,66 @@ TODO Security
 
 ## New EAT Claims {#sec-iana-ear-claims}
 
-TODO
+This specification adds the following values to the "JSON Web Token Claims"
+registry {{IANA.jwt}} and the "CBOR Web Token Claims" registry {{IANA.cwt}}.
+
+Each entry below is an addition to both registries.
+
+The "Claim Description", "Change Controller" and "Specification Documents" are
+common and equivalent for the JWT and CWT registries.
+The "Claim Key" and "Claim Value Types(s)" are for the CWT registry only.
+The "Claim Name" is as defined for the CWT registry, not the JWT registry.
+The "JWT Claim Name" is equivalent to the "Claim Name" in the JWT registry.
+
+### EAR Status
+
+* Claim Name: ear.status
+* Claim Description: EAR Status
+* JWT Claim Name: ear.status
+* Claim Key: 1000
+* Claim Value Type(s): unsigned integer (0, 2, 32, 96)
+* Change Controller: IESG
+* Specification Document(s): {{sec-ear}} of {{&SELF}}
+
+### EAR Trustworthiness Vector
+
+* Claim Name: ear.trustworthiness-vector
+* Claim Description: EAR Trustworthiness Vector
+* JWT Claim Name: ear.trustworthiness-vector
+* Claim Key: 1001
+* Claim Value Type(s): array
+* Change Controller: IESG
+* Specification Document(s): {{sec-ear}} of {{&SELF}}
+
+### EAR Raw Evidence
+
+* Claim Name: ear.raw-evidence
+* Claim Description: EAR Raw Evidence
+* JWT Claim Name: ear.raw-evidence
+* Claim Key: 1002
+* Claim Value Type(s): bytes
+* Change Controller: IESG
+* Specification Document(s): {{sec-ear}} of {{&SELF}}
+
+### EAR Appraisal Policy Identifier
+
+* Claim Name: ear.appraisal-policy-id
+* Claim Description: EAR Appraisal Policy Identifier
+* JWT Claim Name: ear.appraisal-policy-id
+* Claim Key: 1003
+* Claim Value Type(s): text
+* Change Controller: IESG
+* Specification Document(s): {{sec-ear}} of {{&SELF}}
+
+### EAR TEEP Application Claims
+
+* Claim Name: ear.teep-claims
+* Claim Description: EAR TEEP Application Claims
+* JWT Claim Name: ear.teep-claims
+* Claim Key: 1004
+* Claim Value Type(s): array
+* Change Controller: IESG
+* Specification Document(s): {{sec-extensions-teep}} of {{&SELF}}
 
 --- back
 

--- a/draft-fv-rats-ear.md
+++ b/draft-fv-rats-ear.md
@@ -219,7 +219,20 @@ The example in {{fig-ex-json-2}} is a minimalist (successful) attestation result
 
 ## Extensions {#sec-extensions}
 
-TODO
+The EAR claims-set can be extended by plugging new claims into the `$$ear-extension` CDDL socket.
+This specification anticipates two kinds of extensions: standard and custom.
+Standard extensions broaden
+EAR can also accommodate per-application and per-deployment extensions.
+
+Standard extensions can be simple or complex (e.g., sub-maps) claims.
+Standard extensions are registered using the procedure defined in {{sec-iana-ear-ext}}.
+
+Keys for private extensions MUST be chosen as follows:
+
+* negative integers for CBOR serialization
+
+
+In general, a receiver MUST ignore any unknown claim, standard or private.
 
 # Implementation Status
 
@@ -264,7 +277,9 @@ TODO Security
 
 # IANA Considerations
 
-This document has no IANA actions.
+## Standard EAR Key Registry {#sec-iana-ear-ext}
+
+TODO
 
 --- back
 


### PR DESCRIPTION
* Document the TEEP application extension (JSON only for now)
* Provide media types definitions using the EAT media types framework
* Add registrations for the core EAR claims and the TEEP extension

This PR builds on top of #2 

Rendered at https://thomas-fossati.github.io/draft-ear/teep/draft-fv-rats-ear.html