### PR TITLE
nonce: align JWT and CWT representations

### DIFF
--- a/cddl/json-labels.cddl
+++ b/cddl/json-labels.cddl
@@ -17,7 +17,7 @@ eat.submods = "submods"
 ; JWT claims
 iat = "iat"
 
-; ar4si.trustworthiness-vector 
+; ar4si.trustworthiness-vector
 instance-identity = "instance-identity"
 configuration = "configuration"
 executables = "executables"
@@ -36,4 +36,4 @@ developer = "developer"
 build = "build"
 
 ; EAT
-eat.nonce-type = text .size (10..74)
+eat.nonce-type = base64-url-text .size (12..88)

--- a/draft-fv-rats-ear.md
+++ b/draft-fv-rats-ear.md
@@ -165,6 +165,9 @@ See {{sec-ear-appraisal}} for the details about the contents of an
 
 `eat.nonce` (optional)
 : A user supplied nonce that is echoed by the verifier to provide freshness.
+The nonce is a sequence of bytes between 8 and 64 bytes long. When serialized
+as JWT, the nonce MUST be base64 encoded, resulting in a string between 12 and
+88 bytes long.
 See {{Section 4.1 of -eat}}.
 
 `$$ear-extension` (optional)


### PR DESCRIPTION
EAT had separate nonce definitions for JSON and CBOR, defining as a UTF-8 string for the former, and arbitrary bytes for the latter, resulting in incompatible representations.

For the EAR profile, to ensure compatibility between JWT and CWT, and allow maximum flexibility for the user, specify the nonce to be arbitrary bytes, base64-encoded when written as JSON/JWT.

See also the discussion here: https://github.com/ietf-rats-wg/eat/pull/421