### PR TITLE
feat: add topology claim

### DIFF
--- a/cddl/base-files.mk
+++ b/cddl/base-files.mk
@@ -1,6 +1,7 @@
 EAR_BASE_FRAGS += ear.cddl
 EAR_BASE_FRAGS += ear-appraisal.cddl
 EAR_BASE_FRAGS += claims-map.cddl
+EAR_BASE_FRAGS += topology.cddl
 
 EAR_BASE_EXAMPLES += examples/ear-cbor-1.diag
 EAR_BASE_EXAMPLES += examples/ear-json-1.diag

--- a/cddl/ear.cddl
+++ b/cddl/ear.cddl
@@ -11,6 +11,7 @@ EAR = {
   ? raw-evidence-label => cmw-record
   eat.submods-label => { + text => EAR-appraisal }
   ? eat.nonce-label => eat.nonce-type
+  ? topology-label => topology-type
   * $$ear-extension
 }
 
@@ -19,3 +20,4 @@ cmw-record = eat.JC<cmw.json-record, cmw.cbor-record>
 ; EAR-specific claims
 raw-evidence-label = eat.JC<"ear_raw_evidence", 1002>
 verifier-id-label = eat.JC<"ear_verifier_id", 1004>
+topology-label = eat.JC<"ear_device_topology", 1007>

--- a/cddl/ext-teep-files.mk
+++ b/cddl/ext-teep-files.mk
@@ -1,6 +1,7 @@
 EAR_EXT_TEEP_FRAGS += ear.cddl
 EAR_EXT_TEEP_FRAGS += ear-appraisal.cddl
 EAR_EXT_TEEP_FRAGS += claims-map.cddl
+EAR_EXT_TEEP_FRAGS += topology.cddl
 EAR_EXT_TEEP_FRAGS += ext-teep.cddl
 EAR_EXT_TEEP_FRAGS += generic-non-empty.cddl
 EAR_EXT_TEEP_FRAGS += untagged-coswid.cddl

--- a/cddl/ext-veraison-files.mk
+++ b/cddl/ext-veraison-files.mk
@@ -1,6 +1,7 @@
 EAR_EXT_VERAISON_FRAGS += ear.cddl
 EAR_EXT_VERAISON_FRAGS += ear-appraisal.cddl
 EAR_EXT_VERAISON_FRAGS += claims-map.cddl
+EAR_EXT_VERAISON_FRAGS += topology.cddl
 EAR_EXT_VERAISON_FRAGS += ext-veraison.cddl
 
 EAR_EXT_VERAISON_EXAMPLES += examples/ext-veraison-cbor-1.diag

--- a/cddl/topology.cddl
+++ b/cddl/topology.cddl
@@ -1,0 +1,3 @@
+topology-type = {
+  + text => [ + text ]
+}

--- a/draft-ietf-rats-ear.md
+++ b/draft-ietf-rats-ear.md
@@ -187,6 +187,12 @@ as JWT, the nonce MUST be base64 encoded, resulting in a string between 12 and
 88 bytes long.
 See {{Section 4.1 of -eat}}.
 
+`ear_device_topology` (optional)
+: A map that describes the device attester graph using adjacency lists.
+Attesters are represented by their corresponding labels in the `submods` claim.
+Each map key represents an attester in the graph, and the associated map value is an array of labels representing the list of sub-attesters for that attester.
+If the claim is present, the map MUST contain at least one element.
+
 `$$ear-extension` (optional)
 : Any registered or unregistered extension.
 An EAR extension MUST be a map.
@@ -600,21 +606,26 @@ The "JWT Claim Name" is equivalent to the "Claim Name" in the JWT registry.
 * Change Controller: IESG
 * Specification Document(s): {{sec-ear}} of {{&SELF}}
 
+### Device Topology
+
+* Claim Name: ear_device_topology
+* Claim Description: Device Attesters Arrangement
+* JWT Claim Name: ear_device_topology
+* Claim Key: 1007 (suggested)
+* Claim Value Type(s): map
+* Change Controller: IESG
+* Specification Document(s): {{sec-ear}} of {{&SELF}}
+
 ### EAR TEEP Claims
 
 TODO
 
 --- back
 
-# Common CDDL Types {#common-cddl-types}
+# Collated CDDL
 
-{:vspace}
-`non-empty`
-: A CDDL generic that can be used to ensure the presence of at least one item
-in an object with only optional fields.
-
-~~~cddl
-{::include cddl/generic-non-empty.cddl}
+~~~
+{::include-fold cddl/ear-base-autogen.cddl}
 ~~~
 
 # Open Policy Agent Example


### PR DESCRIPTION
Add a "topology" claim to the top-level EAR to describe the composite attester internal arrangement.

Fix #73 